### PR TITLE
SET-22 Updated validateSchema to use readfile

### DIFF
--- a/src/vendor/validateSchema.test.ts
+++ b/src/vendor/validateSchema.test.ts
@@ -19,7 +19,7 @@ describe('validateSignalAgainstSchema', () => {
     }
     expect(await validateSignalAgainstSchemas(signalSet)).toStrictEqual({
       valid: true,
-      schema: '../../examples/express-container/schemas/verificationEvent.json'
+      schema: './examples/express-container/schemas/verificationEvent.json'
     })
   })
 
@@ -39,7 +39,7 @@ describe('validateSignalAgainstSchema', () => {
     }
     expect(await validateSignalAgainstSchemas(signalSet)).toStrictEqual({
       valid: true,
-      schema: '../../examples/express-container/schemas/verificationEvent.json'
+      schema: './examples/express-container/schemas/verificationEvent.json'
     })
   })
 

--- a/src/vendor/validateSchema.ts
+++ b/src/vendor/validateSchema.ts
@@ -1,6 +1,6 @@
 import Ajv, { AnySchema } from 'ajv'
 import addFormats from 'ajv-formats'
-import { readdir } from 'fs/promises'
+import { readdir, readFile } from 'fs/promises'
 
 const ajv = new Ajv()
 addFormats(ajv)
@@ -9,9 +9,11 @@ export async function validateSignalAgainstSchemas(signalSet: unknown) {
   const absoluteSchemaPath = './examples/express-container/schemas'
   const schemaList = await readdir(absoluteSchemaPath)
   for (const schemaName of schemaList) {
-    const filePath = '../.' + absoluteSchemaPath + '/' + schemaName
+    const filePath = absoluteSchemaPath + '/' + schemaName
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    const schema: AnySchema = await import(filePath)
+    const schema: AnySchema = await JSON.parse(
+      await readFile(filePath, { encoding: 'utf8' })
+    )
     const validate = ajv.compile(schema)
     if (validate(signalSet)) {
       return { valid: true, schema: filePath }


### PR DESCRIPTION
Updated validateSchema to use readfile instead of import keeping path to absolute

Ticket Number: https://govukverify.atlassian.net/browse/SET-22

💡 Description
This is a refactor to use readfile to compile the schema in ajv instead of using a dynamic import.
