### PR TITLE
SET-23 Update cosign to v2.4.0 as 1.9.0 is deprecated

### DIFF
--- a/.github/workflows/upload-vendor-testing-image-to-ecr.yaml
+++ b/.github/workflows/upload-vendor-testing-image-to-ecr.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Install Cosign
         uses: sigstore/cosign-installer@d58896d6a1865668819e1d91763c7751a165e159 # v3.9.2
         with:
-          cosign-release: v1.9.0
+          cosign-release: v2.4.0
       - name: Build, tag, and push testing image to Amazon ECR
         env:
           CONTAINER_SIGN_KMS_KEY: ${{ secrets.CONTAINER_SIGN_KMS_KEY }}


### PR DESCRIPTION
Ticket Number: https://govukverify.atlassian.net/browse/SET-23

💡 Description
cosign requires v2.4.0 or higher
